### PR TITLE
Update IslandGuard.java

### DIFF
--- a/src/com/wasteofplastic/askyblock/IslandGuard.java
+++ b/src/com/wasteofplastic/askyblock/IslandGuard.java
@@ -806,7 +806,7 @@ public class IslandGuard implements Listener {
 		    }
 		    return;
 		}
-		if (e.getEntity() instanceof Animals ){
+		if (e.getEntity() instanceof Animals || e.getEntity() instanceof Villager){
 		    //plugin.getLogger().info("Entity is a non-monster - check if ok to hurt"); 
 		    // At spawn?
 		    if (plugin.getGrid().isAtSpawn(e.getEntity().getLocation())) {


### PR DESCRIPTION
The plugin will not allow you to damage villagers if allowPvP is set to false.  This tiny change treats villagers as non-monster animals, rather than as players.