### PR TITLE
fixed bug where restarts to not grab all Warps

### DIFF
--- a/src/com/wasteofplastic/askyblock/WarpSigns.java
+++ b/src/com/wasteofplastic/askyblock/WarpSigns.java
@@ -238,7 +238,7 @@ public class WarpSigns implements Listener {
 		//plugin.getLogger().info("DEBUG: Loading warp at " + l);
 		Block b = l.getBlock();
 		// Check that a warp sign is still there
-		if (b.getType().equals(Material.SIGN_POST)) {
+		if (b.getType().equals(Material.SIGN_POST) || b.getType().equals(Material.WALL_SIGN) {
 		    warpList.put(playerUUID, temp.get(s));
 		} else {
 		    plugin.getLogger().warning("Warp at location " + (String) temp.get(s) + " has no sign - removing.");


### PR DESCRIPTION
The configuration loader only checked for SIGN_POST and not WALL_SIGN, so on every restart/reload, anyone with a WALL_SIGN would have to recreate their warp for them to be included in the list.