### PR TITLE
Correct server JAR path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<server.jars>/Users/ben/serverJars</server.jars>
+		<server.jars>${project.basedir}/lib</server.jars>
 	</properties>
 
 	<build>


### PR DESCRIPTION
Instead of hardcoding the path, this makes Maven find the server JARs in the project directory, under /lib. 
Other contributors can compile the project more easily now.