### PR TITLE
Prevent islands that don't conform to the grid from being added

### DIFF
--- a/src/com/wasteofplastic/askyblock/GridManager.java
+++ b/src/com/wasteofplastic/askyblock/GridManager.java
@@ -534,6 +534,13 @@ public class GridManager {
      */
     private void addToGrids(Island newIsland) {
 	//plugin.getLogger().info("DEBUG: adding island to grid at " + newIsland.getMinX() + "," + newIsland.getMinZ());
+	if (newIsland.getCenter().getBlockX() % Settings.islandDistance != 0
+		|| newIsland.getCenter().getBlockZ() % Settings.islandDistance != 0) {
+		plugin.getLogger().warning("ATTEMPT TO ADD NON-GRID ISLAND: " + newIsland.getCenter().getBlockX() + ","
+			+ newIsland.getCenter().getBlockZ());
+		new Exception().printStackTrace(System.out);
+		return;
+	}
 	if (newIsland.getOwner() != null) {
 	    ownershipMap.put(newIsland.getOwner(), newIsland);
 	}


### PR DESCRIPTION
This fixes occasional mistakes in the bedrock detector or islands.yml file, resulting in players being locked out of their islands