### PR TITLE
Ignore cancelled messages

### DIFF
--- a/src/com/wasteofplastic/askyblock/listeners/ChatListener.java
+++ b/src/com/wasteofplastic/askyblock/listeners/ChatListener.java
@@ -55,7 +55,7 @@ public class ChatListener implements Listener {
     }
 
     
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onChat(final AsyncPlayerChatEvent event) {
 	// Substitute variable - thread safe
 	String level = "";


### PR DESCRIPTION
Some plugins may cancel chat messages for a good reason, so it would be good to not display them.