### PR TITLE
Removes lag spikes on island creation.

### DIFF
--- a/src/com/wasteofplastic/askyblock/GridManager.java
+++ b/src/com/wasteofplastic/askyblock/GridManager.java
@@ -386,12 +386,15 @@ public class GridManager {
 	}
 	islandYaml.set(Settings.worldName, islandList);
 	// Save the file
-	try {
-	    islandYaml.save(islandFile);
-	} catch (Exception e) {
-	    plugin.getLogger().severe("Could not save islands.yml!");
-	    e.printStackTrace();
-	}
+	Bukkit.getScheduler().runTaskAsynchronously(plugin, new Runnable() {
+	public void run() {
+		try {
+		    islandYaml.save(islandFile);
+		} catch (Exception e) {
+		    plugin.getLogger().severe("Could not save islands.yml!");
+		    e.printStackTrace();
+		}}
+	  });
     }
 
     /**


### PR DESCRIPTION
I saw that when creating an island the ms spikes were above 1000, which was resulting in tps drops for us when there was 200 players on so I started debugging and noticed that the saveGrid method was the cause