### PR TITLE
Use last team.maxsize permissions

### DIFF
--- a/src/com/wasteofplastic/askyblock/commands/IslandCmd.java
+++ b/src/com/wasteofplastic/askyblock/commands/IslandCmd.java
@@ -2269,11 +2269,11 @@ public class IslandCmd implements CommandExecutor, TabCompleter {
 					    // Dynamic team sizes with permissions
 					    for (PermissionAttachmentInfo perms : player.getEffectivePermissions()) {
 						if (perms.getPermission().startsWith(Settings.PERMPREFIX + "team.maxsize.")) {
-						    // Prevent the situation where the player has 
+						    // Prevent the situation where the player has multiple permissions
 						    String[] permSplit = perms.getPermission().split(Settings.PERMPREFIX + "team.maxsize.");
 						    if (permSplit.length == 2) {
 							try {
-							    maxSize = Integer.valueOf(permSplit[1]);
+							    maxSize = Math.max(maxSize, Integer.valueOf(permSplit[1]));
 							} catch (Exception e) {
 							    plugin.getLogger().severe("Max team perm for player " + player.getName() + " cannot be parsed " + perms.getPermission());
 							}


### PR DESCRIPTION
Currently, team size is based on the latest permissions found. Using Math.max (like you did for /i invite without args) solves the bug.