### PR TITLE
Add getChallengeTimes(UUID) to API

### DIFF
--- a/src/com/wasteofplastic/askyblock/ASkyBlockAPI.java
+++ b/src/com/wasteofplastic/askyblock/ASkyBlockAPI.java
@@ -62,6 +62,16 @@ public class ASkyBlockAPI {
     public HashMap<String, Boolean> getChallengeStatus(UUID playerUUID) {
         return new HashMap<String, Boolean>(plugin.getPlayers().getChallengeStatus(playerUUID));
     }
+    
+    /**
+     * @param playerUUID
+     * @return HashMap of all of the known challenges and how many times each
+     *         one has been completed. This is a copy of the challenges
+     *         and changing this list will not affect the actual list.
+     */
+    public HashMap<String, Integer> getChallengeTimes(UUID playerUUID) {
+        return new HashMap<String, Integer>(plugin.getPlayers().getChallengeTimes(playerUUID));
+    }
 
     public Location getHomeLocation(UUID playerUUID) {
         return plugin.getPlayers().getHomeLocation(playerUUID,1);

--- a/src/com/wasteofplastic/askyblock/ASkyBlockAPI.java
+++ b/src/com/wasteofplastic/askyblock/ASkyBlockAPI.java
@@ -55,22 +55,22 @@ public class ASkyBlockAPI {
 
     /**
      * @param playerUUID
-     * @return HashMap of all of the known challenges with a boolean marking
-     *         them as complete (true) or incomplete (false). This is a copy of the challenges
-     *         and changing this list will not affect the actual list.
+     * @return Map of all of the known challenges with a boolean marking
+     *         them as complete (true) or incomplete (false). This is a view of the
+     *         challenges map that only allows read operations.
      */
-    public HashMap<String, Boolean> getChallengeStatus(UUID playerUUID) {
-        return new HashMap<String, Boolean>(plugin.getPlayers().getChallengeStatus(playerUUID));
+    public Map<String, Boolean> getChallengeStatus(UUID playerUUID) {
+        return Collections.unmodifiableMap(plugin.getPlayers().getChallengeStatus(playerUUID));
     }
     
     /**
      * @param playerUUID
-     * @return HashMap of all of the known challenges and how many times each
-     *         one has been completed. This is a copy of the challenges
-     *         and changing this list will not affect the actual list.
+     * @return Map of all of the known challenges and how many times each
+     *         one has been completed. This is a view of the challenges
+     *         map that only allows read operations.
      */
-    public HashMap<String, Integer> getChallengeTimes(UUID playerUUID) {
-        return new HashMap<String, Integer>(plugin.getPlayers().getChallengeTimes(playerUUID));
+    public Map<String, Integer> getChallengeTimes(UUID playerUUID) {
+        return Collections.unmodifiableMap(plugin.getPlayers().getChallengeTimes(playerUUID));
     }
 
     public Location getHomeLocation(UUID playerUUID) {


### PR DESCRIPTION
This is untested, but it should work.

Also, it duplicates the map as getChallengeStatus does, but why don't you use Collections.unmodifiableMap() to return a view of it ?
I mean, why would someone want the challenge map in order to modify it ? And if he really want to, he just has to copy it, while all others who use this API would retrieve a unmodifiable view, with no performance costs.