### PR TITLE
Implement events for players joining and leaving teams

### DIFF
--- a/src/com/wasteofplastic/askyblock/Players.java
+++ b/src/com/wasteofplastic/askyblock/Players.java
@@ -16,20 +16,16 @@
  *******************************************************************************/
 package com.wasteofplastic.askyblock;
 
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map.Entry;
-import java.util.UUID;
-
+import com.wasteofplastic.askyblock.events.TeamJoinEvent;
+import com.wasteofplastic.askyblock.events.TeamLeaveEvent;
+import com.wasteofplastic.askyblock.util.Util;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 
-import com.wasteofplastic.askyblock.util.Util;
+import java.util.*;
+import java.util.Map.Entry;
 
 /**
  * Tracks the following info on the player
@@ -617,9 +613,15 @@ public class Players {
      *            String in this function)
      */
     public void setJoinTeam(final UUID leader, final Location l) {
+        if(inTeam) {
+            Bukkit.getPluginManager().callEvent(new TeamLeaveEvent(uuid, teamLeader));
+        }
+
         inTeam = true;
         teamLeader = leader;
         teamIslandLocation = Util.getStringLocation(l);
+
+        Bukkit.getPluginManager().callEvent(new TeamJoinEvent(uuid, leader));
     }
 
     /**
@@ -628,11 +630,15 @@ public class Players {
      */
 
     public void setLeaveTeam() {
+        if(inTeam) {
+            Bukkit.getPluginManager().callEvent(new TeamLeaveEvent(uuid, teamLeader));
+        }
+
         inTeam = false;
         teamLeader = null;
         islandLevel = 0;
         teamIslandLocation = null;
-        members = new ArrayList<UUID>();
+        members = new ArrayList<>();
     }
 
     /**
@@ -648,7 +654,15 @@ public class Players {
      *            a String name of the team leader
      */
     public void setTeamLeader(final UUID leader) {
+        if(inTeam) {
+            // Changing team leader changes the team identifier
+            Bukkit.getPluginManager().callEvent(new TeamLeaveEvent(uuid, teamLeader));
+        }
+
         teamLeader = leader;
+        if(leader != null) {
+            Bukkit.getPluginManager().callEvent(new TeamJoinEvent(uuid, leader));
+        }
     }
 
     /**

--- a/src/com/wasteofplastic/askyblock/events/TeamJoinEvent.java
+++ b/src/com/wasteofplastic/askyblock/events/TeamJoinEvent.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * This file is part of ASkyBlock.
+ *
+ *     ASkyBlock is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     ASkyBlock is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with ASkyBlock.  If not, see <http://www.gnu.org/licenses/>.
+ *******************************************************************************/
+
+package com.wasteofplastic.askyblock.events;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import java.util.UUID;
+
+/**
+ * This event is fired when a player joins a new Team
+ * 
+ * @author Exloki
+ * 
+ */
+public class TeamJoinEvent extends Event {
+    private static final HandlerList handlers = new HandlerList();
+
+    private final UUID player;
+    private final UUID newTeamLeader;
+
+    public TeamJoinEvent(UUID player, UUID newTeamLeader) {
+        this.player = player;
+        this.newTeamLeader = newTeamLeader;
+    }
+
+    /**
+     * The UUID of the player changing Team
+     * @return the player UUID
+     */
+    public UUID getPlayer() {
+        return player;
+    }
+
+    /**
+     * The UUID of the new Team's Leader
+     * @return the team leader
+     */
+    public UUID getNewTeamLeader() {
+        return newTeamLeader;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/com/wasteofplastic/askyblock/events/TeamLeaveEvent.java
+++ b/src/com/wasteofplastic/askyblock/events/TeamLeaveEvent.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * This file is part of ASkyBlock.
+ *
+ *     ASkyBlock is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     ASkyBlock is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with ASkyBlock.  If not, see <http://www.gnu.org/licenses/>.
+ *******************************************************************************/
+
+package com.wasteofplastic.askyblock.events;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import java.util.UUID;
+
+/**
+ * This event is fired when a player leaves an existing Team
+ * 
+ * @author Exloki
+ * 
+ */
+public class TeamLeaveEvent extends Event {
+    private static final HandlerList handlers = new HandlerList();
+
+    private final UUID player;
+    private final UUID oldTeamLeader;
+
+    public TeamLeaveEvent(UUID player, UUID oldTeamLeader) {
+        this.player = player;
+        this.oldTeamLeader = oldTeamLeader;
+    }
+
+    /**
+     * The UUID of the player changing Team
+     * @return the player UUID
+     */
+    public UUID getPlayer() {
+        return player;
+    }
+
+    /**
+     * The UUID of the player's previous Team's Leader
+     * @return the team leader
+     */
+    public UUID getOldTeamLeader() {
+        return oldTeamLeader;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}


### PR DESCRIPTION
As the title describes; we use this addition on a large Skyblock server for features in some of our custom plugins, and having this implemented to the master branch of askyblock would be extremely helpful.