### PR TITLE
Add MUSHROOM_STEW to the worldedit to material map

### DIFF
--- a/src/com/wasteofplastic/askyblock/schematics/IslandBlock.java
+++ b/src/com/wasteofplastic/askyblock/schematics/IslandBlock.java
@@ -164,6 +164,7 @@ public class IslandBlock {
         WEtoM.put("WOODEN_SHOVEL",Material.WOOD_SPADE);
         WEtoM.put("WOODEN_SLAB",Material.WOOD_STEP);
         WEtoM.put("WOODEN_SWORD",Material.WOOD_SWORD);
+        WEtoM.put("MUSHROOM_STEW",Material.MUSHROOM_SOUP);
         // Entities
         WEtoME.put("LAVASLIME", EntityType.MAGMA_CUBE);
         WEtoME.put("ENTITYHORSE", EntityType.HORSE);


### PR DESCRIPTION
Error:
[14:35:52] [Server thread/ERROR]: Could not parse item [MUSHROOM_STEW] in schematic - skipping!
[14:35:52] [Server thread/WARN]: java.lang.IllegalArgumentException: No enum constant org.bukkit.Material.MUSHROOM_STEW

Mushroom Stew:
![image](https://cloud.githubusercontent.com/assets/2774281/20642862/09a31ada-b3e0-11e6-817e-02e9845e88be.png)

Problem:
In minecraft, the ítem is called msuhroom_stew, while in bukkit it is called mushroom_soup, (wierd)
https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html#MUSHROOM_SOUP