### PR TITLE
Added option to disable Metrics

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -11,6 +11,11 @@
 #
 ##############################################################################
 
+# ASkyBlock uses bStats.org to get global data about the plugin to help improving it.
+# bStats has nearly no effect on your server's performance and the sent data is completely 
+# anonymous so please consider twice if you really want to disable it.
+metrics: true
+
 ##### Island Related Settings #####
 
 island:

--- a/src/com/wasteofplastic/askyblock/ASkyBlock.java
+++ b/src/com/wasteofplastic/askyblock/ASkyBlock.java
@@ -356,7 +356,9 @@ public class ASkyBlock extends JavaPlugin {
             getServer().getPluginManager().registerEvents(new WorldLoader(this), this);
         }
         // Metrics
-        new MetricsLite(this);
+        if(Settings.metrics){
+            new MetricsLite(this);
+        }
         // Kick off a few tasks on the next tick
         // By calling getIslandWorld(), if there is no island
         // world, it will be created
@@ -379,7 +381,7 @@ public class ASkyBlock extends JavaPlugin {
                     if (Settings.GAMETYPE.equals(Settings.GameType.ASKYBLOCK)) {
                         getCommand("island").setExecutor(new NotSetup(Reason.GENERATOR));
                         getCommand("asc").setExecutor(new NotSetup(Reason.GENERATOR));
-                        getCommand("asadmin").setExecutor(new NotSetup(Reason.GENERATOR));
+                        getCommand("asadmin").setExecutor(new NotSetup(Reason.GENERATOR));  
                     } else {
                         getCommand("ai").setExecutor(new NotSetup(Reason.GENERATOR));
                         getCommand("aic").setExecutor(new NotSetup(Reason.GENERATOR));

--- a/src/com/wasteofplastic/askyblock/PluginConfig.java
+++ b/src/com/wasteofplastic/askyblock/PluginConfig.java
@@ -50,6 +50,8 @@ public class PluginConfig {
             e.printStackTrace();
         }
         // The order in this file should match the order in config.yml so that it is easy to check that everything is covered
+        Settings.metrics = plugin.getConfig().getBoolean("metrics", true);
+        
         // ********************** Island settings **************************
         Settings.islandDistance = plugin.getConfig().getInt("island.distance", 200);
         if (Settings.islandDistance < 50) {

--- a/src/com/wasteofplastic/askyblock/Settings.java
+++ b/src/com/wasteofplastic/askyblock/Settings.java
@@ -73,6 +73,7 @@ public class Settings {
 
     /*		MAIN SETTINGS		*/
     public static boolean updateCheck;
+    public static boolean metrics;
     
     public static long backupDuration;
     


### PR DESCRIPTION
Just in case the server owner don't want bStats to get data
(And, btw, I noticed that providing an option to disable metrics make the owner more confident in the plugin itself, so he will be more induced in keeping metrics enabled.
Yep, human psychology ^^)