### PR TITLE
Fix NPE when getting island that doesn't exist

### DIFF
--- a/src/com/wasteofplastic/askyblock/ASkyBlockAPI.java
+++ b/src/com/wasteofplastic/askyblock/ASkyBlockAPI.java
@@ -445,7 +445,11 @@ public class ASkyBlockAPI {
      * @return copy of Island object
      */
     public Island getIslandOwnedBy(UUID playerUUID) {
-        return new Island(plugin.getGrid().getIsland(playerUUID));
+        Island island = plugin.getGrid().getIsland(playerUUID);
+        if (island != null) {
+            new Island(island);
+        }
+        return null;
     }
 
     /**
@@ -454,7 +458,11 @@ public class ASkyBlockAPI {
      * @return copy of Island object
      */
     public Island getIslandAt(Location location) {
-        return new Island(plugin.getGrid().getIslandAt(location));
+        Island island = plugin.getGrid().getIslandAt(location);
+        if (island != null) {
+            new Island(island);
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
This fixes a NullPointerException that was introduced in 98905962054a29b60afac60bfd4a7625593f3e14 when the API started to return a copy of the island. This also solves the issue where it doesn't match the docs of returning null if it doesn't exist.