### PR TITLE
Add setting to specify if coop invites are instant

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -605,6 +605,10 @@ general:
    # Island members wont be able to coop other players.
    onlyleadercancoop: false
 
+   # Set whether or not players can reject coop requests.
+   # If set to false players are just directly added as a coop player.
+   coopisrequest: true
+
    # Below you can list all account names that ASkyBlock will ignore for some protection.
    # Configure it at your own risk!!
    # This option is mainly for compatibility with mods.

--- a/src/com/wasteofplastic/askyblock/PluginConfig.java
+++ b/src/com/wasteofplastic/askyblock/PluginConfig.java
@@ -683,6 +683,8 @@ public class PluginConfig {
         Settings.persistantCoops = plugin.getConfig().getBoolean("general.persistentcoops");
         // Only leader can coop
         Settings.onlyLeaderCanCoop = plugin.getConfig().getBoolean("general.onlyleadercancoop", false);
+        // Can coop requests be rejected
+        Settings.coopIsRequest = plugin.getConfig().getBoolean("general.coopisrequest", true);
 
         // Fake players
         Settings.allowedFakePlayers = plugin.getConfig().getStringList("general.fakeplayers");

--- a/src/com/wasteofplastic/askyblock/Settings.java
+++ b/src/com/wasteofplastic/askyblock/Settings.java
@@ -130,6 +130,7 @@ public class Settings {
     public static boolean damageOps;
     public static boolean endermanDeathDrop;
     public static boolean onlyLeaderCanCoop;
+    public static boolean coopIsRequest;
 
     // Invincible visitor
     public static boolean invincibleVisitors;

--- a/src/com/wasteofplastic/askyblock/commands/IslandCmd.java
+++ b/src/com/wasteofplastic/askyblock/commands/IslandCmd.java
@@ -2624,28 +2624,40 @@ public class IslandCmd implements CommandExecutor, TabCompleter {
                                 Util.sendMessage(player, ChatColor.RED + plugin.myLocale(player.getUniqueId()).inviteerrorCoolDown.replace("[time]", String.valueOf(time)));
                                 return true;
                             }
-                            // Send out coop invite
-                            Util.sendMessage(player, ChatColor.GREEN + plugin.myLocale(player.getUniqueId()).inviteinviteSentTo.replace("[name]", target.getName()));
-                            Util.sendMessage(target, ChatColor.GREEN + plugin.myLocale(targetPlayerUUID).coopHasInvited.replace("[name]", player.getName()));
-                            Util.sendMessage(target, ChatColor.WHITE + "/" + label + " [coopaccept/coopreject] " + ChatColor.YELLOW + plugin.myLocale(targetPlayerUUID).invitetoAcceptOrReject);
-                            coopInviteList.put(targetPlayerUUID, playerUUID);
-                            if (Settings.inviteTimeout > 0) {
-                                plugin.getServer().getScheduler().runTaskLater(plugin, new Runnable() {
 
-                                    @Override
-                                    public void run() {
+                            if (Settings.coopIsRequest) {
+                                // Send out coop invite
+                                Util.sendMessage(player, ChatColor.GREEN + plugin.myLocale(player.getUniqueId()).inviteinviteSentTo.replace("[name]", target.getName()));
+                                Util.sendMessage(target, ChatColor.GREEN + plugin.myLocale(targetPlayerUUID).coopHasInvited.replace("[name]", player.getName()));
+                                Util.sendMessage(target, ChatColor.WHITE + "/" + label + " [coopaccept/coopreject] " + ChatColor.YELLOW + plugin.myLocale(targetPlayerUUID).invitetoAcceptOrReject);
+                                coopInviteList.put(targetPlayerUUID, playerUUID);
+                                if (Settings.inviteTimeout > 0) {
+                                    plugin.getServer().getScheduler().runTaskLater(plugin, new Runnable() {
 
-                                        if (coopInviteList.containsKey(targetPlayerUUID) && coopInviteList.get(targetPlayerUUID).equals(playerUUID)) {
-                                            coopInviteList.remove(targetPlayerUUID);
-                                            if (plugin.getServer().getPlayer(playerUUID) != null) {
-                                                Util.sendMessage(plugin.getServer().getPlayer(playerUUID), ChatColor.YELLOW + plugin.myLocale(player.getUniqueId()).inviteremovingInvite);
+                                        @Override
+                                        public void run() {
+
+                                            if (coopInviteList.containsKey(targetPlayerUUID) && coopInviteList.get(targetPlayerUUID).equals(playerUUID)) {
+                                                coopInviteList.remove(targetPlayerUUID);
+                                                if (plugin.getServer().getPlayer(playerUUID) != null) {
+                                                    Util.sendMessage(plugin.getServer().getPlayer(playerUUID), ChatColor.YELLOW + plugin.myLocale(player.getUniqueId()).inviteremovingInvite);
+                                                }
+                                                if (plugin.getServer().getPlayer(targetPlayerUUID) != null) {
+                                                    Util.sendMessage(plugin.getServer().getPlayer(targetPlayerUUID), ChatColor.YELLOW + plugin.myLocale(player.getUniqueId()).inviteremovingInvite);
+                                                }
                                             }
-                                            if (plugin.getServer().getPlayer(targetPlayerUUID) != null) {
-                                                Util.sendMessage(plugin.getServer().getPlayer(targetPlayerUUID), ChatColor.YELLOW + plugin.myLocale(player.getUniqueId()).inviteremovingInvite);
-                                            }
+
                                         }
-
-                                    }}, Settings.inviteTimeout);
+                                    }, Settings.inviteTimeout);
+                                }
+                            } else {
+                                // Add target to coop list
+                                if (CoopPlay.getInstance().addCoopPlayer(player, target)) {
+                                    // Tell everyone what happened
+                                    Util.sendMessage(player, ChatColor.GREEN + plugin.myLocale(player.getUniqueId()).coopSuccess.replace("[name]", target.getName()));
+                                    Util.sendMessage(target, ChatColor.GREEN + plugin.myLocale(targetPlayerUUID).coopMadeYouCoop.replace("[name]", player.getName()));
+                                    // TODO: Give perms if the player is on the coop island
+                                } // else fail silently
                             }
                             return true;
                         } else if (split[0].equalsIgnoreCase("expel")) {


### PR DESCRIPTION
Some people prefer the old way of instant coop without having to confirm the request so this just adds a settings value to let people return to the old behaviour. (it's set to use the new requests by default though)