### PR TITLE
Changed challenge inventory

### DIFF
--- a/src/com/wasteofplastic/askyblock/commands/Challenges.java
+++ b/src/com/wasteofplastic/askyblock/commands/Challenges.java
@@ -78,6 +78,7 @@ public class Challenges implements CommandExecutor, TabCompleter {
     // Database of challenges
     private static LinkedHashMap<String, List<String>> challengeList = new LinkedHashMap<String, List<String>>();
     private HashMap<UUID, List<CPItem>> playerChallengeGUI = new HashMap<UUID, List<CPItem>>();
+    private HashMap<UUID, String> playerChallengeLevel = new HashMap<UUID, String>();
     private YamlConfiguration resettingChallenges;
     // Where challenges are stored
     private static FileConfiguration challengeFile = null;
@@ -1646,14 +1647,20 @@ public class Challenges implements CommandExecutor, TabCompleter {
      * @return inventory
      */
     public Inventory challengePanel(Player player) {
-        String maxLevel = "";
-        for (String level : Settings.challengeLevels) {
-            if (checkLevelCompletion(player, level) > 0) {
-                maxLevel = level;
-                break;
-            }
+    	if(playerChallengeLevel.containsKey(player.getUniqueId())) {	
+    		String level = playerChallengeLevel.get(player.getUniqueId());	  
+    		return challengePanel(player, level);
+        }else {
+        	String maxLevel = "";
+        	for (String level : Settings.challengeLevels) {
+	            if (checkLevelCompletion(player, level) > 0) {
+	                maxLevel = level;
+	                break;
+	            }
+	        }
+        	return challengePanel(player, maxLevel);
         }
-        return challengePanel(player, maxLevel);
+        
     }
 
     /**
@@ -1742,6 +1749,7 @@ public class Challenges implements CommandExecutor, TabCompleter {
             Inventory newPanel = Bukkit.createInventory(null, size, plugin.myLocale(player.getUniqueId()).challengesguiTitle);
             // Store the panel details for retrieval later
             playerChallengeGUI.put(player.getUniqueId(), cp);
+            playerChallengeLevel.put(player.getUniqueId(), level);
             // Fill the inventory and return
             int index = 0;
             for (CPItem i : cp) {

--- a/src/com/wasteofplastic/askyblock/panels/ControlPanel.java
+++ b/src/com/wasteofplastic/askyblock/panels/ControlPanel.java
@@ -245,13 +245,42 @@ public class ControlPanel implements Listener {
                     // Next section indicates the level of panel to open
                     if (item.getNextSection() != null) {
                         inventory.clear();
+                        Inventory newInventory = plugin.getChallenges().challengePanel(player, item.getNextSection());
+                        // Update inventory
+                        if(player.getOpenInventory().getTopInventory() != null) {                        	
+                        	if(inventory.equals(player.getOpenInventory().getTopInventory())) {
+                        		if(inventory.getSize() == newInventory.getSize()) {
+                        			inventory.setContents(newInventory.getContents());
+                        			return;
+                        		}
+                        	}
+                        }
+                        // Open new Inventory if update is not possible
                         player.closeInventory();
-                        player.openInventory(plugin.getChallenges().challengePanel(player, item.getNextSection()));
+                        player.openInventory(newInventory);
+                        
+                        
                     } else if (item.getCommand() != null) {
                         Util.runCommand(player, item.getCommand());
-                        inventory.clear();
+                        inventory.clear();                        
+                        
+                        // Update inventory
+                        if(player.getOpenInventory().getTopInventory() != null) {
+                        	if(inventory.equals(player.getOpenInventory().getTopInventory())) {
+                        		Inventory newInventory = plugin.getChallenges().challengePanel(player);
+                        		if(inventory.getSize() == newInventory.getSize()) {
+                        			inventory.setContents(newInventory.getContents());
+                        			return;
+                        		}
+                        	}
+                        }
+                        
+                        // Open new Inventory if update is not possible
                         player.closeInventory();
                         Bukkit.getScheduler().runTask(plugin, () -> player.openInventory(plugin.getChallenges().challengePanel(player)));
+                        
+                        
+                        
                     }
                 }
             }


### PR DESCRIPTION
A few of our players wanted to complete a novice challenge many times. Every time they completed the challenge the challenge inventory displayed there max challenge level. They than had to select novice again.

This PR reduces the clicks required to complete a challenge many times in a row by updating the inventory instead of opening the first level again.

Not sure if this is something that should be in the main plugin, but our players requested it so I might as well share :3