### PR TITLE
Fix a bad typo in CoopLeaveEvent

### DIFF
--- a/src/com/wasteofplastic/askyblock/events/CoopLeaveEvent.java
+++ b/src/com/wasteofplastic/askyblock/events/CoopLeaveEvent.java
@@ -41,7 +41,7 @@ public class CoopLeaveEvent extends ASkyBlockEvent implements Cancellable {
      * @param island
      */
     public CoopLeaveEvent(UUID expelledPlayer, UUID expellingPlayer, Island island) {
-        super(expellingPlayer, island);
+        super(expelledPlayer, island);
         this.expeller = expellingPlayer;
         //Bukkit.getLogger().info("DEBUG: Coop leave event " + Bukkit.getServer().getOfflinePlayer(expelledPlayer).getName() + " was expelled from " 
         //	+ Bukkit.getServer().getOfflinePlayer(expellingPlayer).getName() + "'s island.");


### PR DESCRIPTION
I know you no-longer maintain this repo, but I still use it and I really need this change.

I tried to compile myself but some dependencies are missing:
```
[ERROR] Failed to execute goal on project askyblock: Could not resolve dependencies for project com.wasteofplastic:askyblock:jar:3.0.9.4: The following artifacts could not be resolved: bukkit.org:craftbukkit:jar:1.7.9, spigotmc.org:spigot-1.9.2:jar:1.9.2, spigotmc.org:spigot-1.9.4:jar:1.9.4, spigotmc.org:spigot-1.12:jar:1.12, spigotmc.org:spigot-1.10:jar:1.10, spigotmc.org:spigot-1.11:jar:1.11, spigotmc.org:spigot-1.9:jar:1.9, spigotmc.org:spigot-1.8:jar:1.8, spigotmc.org:spigot.1.8.3:jar:1.8.3, spigotmc.org:spigot.1.8.4:jar:1.8.4, spigotmc.org:spigot.1.8.6:jar:1.8.6, spigotmc.org:spigot.1.8.8:jar:1.8.8, spigotmc.org:spigot-1649:jar:1.7.10: Could not find artifact bukkit.org:craftbukkit:jar:1.7.9 at specified path [...]/askyblock/lib/craftbukkit-1.7.9-R0.3-20140705.002733-4.jar -> [Help 1]
```

Hope you can help me through it :)